### PR TITLE
feat: add webhook signature verification helper

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.22
 
 require (
 	github.com/spyzhov/ajson v0.8.0
+	github.com/standard-webhooks/standard-webhooks/libraries v0.0.0-20250711233419-a173a6c0125c
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/spyzhov/ajson v0.8.0 h1:sFXyMbi4Y/BKjrsfkUZHSjA2JM1184enheSjjoT/zCc=
 github.com/spyzhov/ajson v0.8.0/go.mod h1:63V+CGM6f1Bu/p4nLIN8885ojBdt88TbLoSFzyqMuVA=
+github.com/standard-webhooks/standard-webhooks/libraries v0.0.0-20250711233419-a173a6c0125c h1:Mm99t6GdFMtZOwyyvu3q8gXeZX0sqnjvimTC9QCJwQc=
+github.com/standard-webhooks/standard-webhooks/libraries v0.0.0-20250711233419-a173a6c0125c/go.mod h1:L1MQhA6x4dn9r007T033lsaZMv9EmBAdXyU/+EF40fo=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/webhook_verification.go
+++ b/webhook_verification.go
@@ -1,0 +1,45 @@
+package polargo
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+
+	standardwebhooks "github.com/standard-webhooks/standard-webhooks/libraries/go"
+)
+
+// WebhookVerifier handles verification of incoming Polar webhook signatures.
+// Polar uses the Standard Webhooks specification for signing webhook payloads.
+type WebhookVerifier struct {
+	wh *standardwebhooks.Webhook
+}
+
+// NewWebhookVerifier creates a new WebhookVerifier with the provided webhook secret.
+// The secret should be the raw webhook secret string from your Polar dashboard.
+func NewWebhookVerifier(secret string) (*WebhookVerifier, error) {
+	// Standard webhooks expects base64 encoded secret
+	encodedSecret := base64.StdEncoding.EncodeToString([]byte(secret))
+	wh, err := standardwebhooks.NewWebhook(encodedSecret)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create webhook verifier: %w", err)
+	}
+	return &WebhookVerifier{wh: wh}, nil
+}
+
+// Verify validates the webhook payload against the signature in the request headers.
+// It checks the webhook-id, webhook-timestamp, and webhook-signature headers.
+// Returns nil if the signature is valid, otherwise returns an error.
+func (v *WebhookVerifier) Verify(payload []byte, headers http.Header) error {
+	return v.wh.Verify(payload, headers)
+}
+
+// ValidateWebhookSignature is a convenience function that creates a verifier and
+// validates the webhook signature in a single call.
+// The secret should be the raw webhook secret string from your Polar dashboard.
+func ValidateWebhookSignature(payload []byte, headers http.Header, secret string) error {
+	verifier, err := NewWebhookVerifier(secret)
+	if err != nil {
+		return err
+	}
+	return verifier.Verify(payload, headers)
+}

--- a/webhook_verification_test.go
+++ b/webhook_verification_test.go
@@ -1,0 +1,136 @@
+package polargo
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testSecret = "whsec_test_secret_key_for_testing"
+
+// generateTestSignature creates a valid webhook signature for testing
+func generateTestSignature(payload []byte, secret string, timestamp int64, msgID string) string {
+	// Standard webhooks signature format: v1,<base64-hmac-sha256>
+	toSign := fmt.Sprintf("%s.%d.%s", msgID, timestamp, string(payload))
+
+	// Decode the base64 secret (standard webhooks expects base64 encoded secret)
+	encodedSecret := base64.StdEncoding.EncodeToString([]byte(secret))
+	decodedSecret, _ := base64.StdEncoding.DecodeString(encodedSecret)
+
+	h := hmac.New(sha256.New, decodedSecret)
+	h.Write([]byte(toSign))
+	signature := base64.StdEncoding.EncodeToString(h.Sum(nil))
+
+	return "v1," + signature
+}
+
+func TestNewWebhookVerifier(t *testing.T) {
+	t.Run("creates verifier with valid secret", func(t *testing.T) {
+		verifier, err := NewWebhookVerifier(testSecret)
+		require.NoError(t, err)
+		assert.NotNil(t, verifier)
+	})
+
+	t.Run("creates verifier with empty secret", func(t *testing.T) {
+		// Empty secret should still create a verifier (validation happens at verify time)
+		verifier, err := NewWebhookVerifier("")
+		require.NoError(t, err)
+		assert.NotNil(t, verifier)
+	})
+}
+
+func TestWebhookVerifier_Verify(t *testing.T) {
+	payload := []byte(`{"type":"customer.updated","data":{"id":"123"}}`)
+	timestamp := time.Now().Unix()
+	msgID := "msg_test123"
+
+	t.Run("valid signature passes verification", func(t *testing.T) {
+		verifier, err := NewWebhookVerifier(testSecret)
+		require.NoError(t, err)
+
+		signature := generateTestSignature(payload, testSecret, timestamp, msgID)
+
+		headers := http.Header{}
+		headers.Set("webhook-id", msgID)
+		headers.Set("webhook-timestamp", strconv.FormatInt(timestamp, 10))
+		headers.Set("webhook-signature", signature)
+
+		err = verifier.Verify(payload, headers)
+		assert.NoError(t, err)
+	})
+
+	t.Run("invalid signature fails verification", func(t *testing.T) {
+		verifier, err := NewWebhookVerifier(testSecret)
+		require.NoError(t, err)
+
+		headers := http.Header{}
+		headers.Set("webhook-id", msgID)
+		headers.Set("webhook-timestamp", strconv.FormatInt(timestamp, 10))
+		headers.Set("webhook-signature", "v1,invalidsignature")
+
+		err = verifier.Verify(payload, headers)
+		assert.Error(t, err)
+	})
+
+	t.Run("missing headers fails verification", func(t *testing.T) {
+		verifier, err := NewWebhookVerifier(testSecret)
+		require.NoError(t, err)
+
+		headers := http.Header{}
+		// Missing all required headers
+
+		err = verifier.Verify(payload, headers)
+		assert.Error(t, err)
+	})
+
+	t.Run("wrong secret fails verification", func(t *testing.T) {
+		verifier, err := NewWebhookVerifier("wrong_secret")
+		require.NoError(t, err)
+
+		signature := generateTestSignature(payload, testSecret, timestamp, msgID)
+
+		headers := http.Header{}
+		headers.Set("webhook-id", msgID)
+		headers.Set("webhook-timestamp", strconv.FormatInt(timestamp, 10))
+		headers.Set("webhook-signature", signature)
+
+		err = verifier.Verify(payload, headers)
+		assert.Error(t, err)
+	})
+}
+
+func TestValidateWebhookSignature(t *testing.T) {
+	payload := []byte(`{"type":"subscription.active","data":{"id":"sub_123"}}`)
+	timestamp := time.Now().Unix()
+	msgID := "msg_sub_test"
+
+	t.Run("convenience function works with valid signature", func(t *testing.T) {
+		signature := generateTestSignature(payload, testSecret, timestamp, msgID)
+
+		headers := http.Header{}
+		headers.Set("webhook-id", msgID)
+		headers.Set("webhook-timestamp", strconv.FormatInt(timestamp, 10))
+		headers.Set("webhook-signature", signature)
+
+		err := ValidateWebhookSignature(payload, headers, testSecret)
+		assert.NoError(t, err)
+	})
+
+	t.Run("convenience function fails with invalid signature", func(t *testing.T) {
+		headers := http.Header{}
+		headers.Set("webhook-id", msgID)
+		headers.Set("webhook-timestamp", strconv.FormatInt(timestamp, 10))
+		headers.Set("webhook-signature", "v1,bad_signature")
+
+		err := ValidateWebhookSignature(payload, headers, testSecret)
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
## Summary

- Adds `WebhookVerifier` struct for verifying incoming Polar webhook signatures
- Adds `ValidateWebhookSignature` convenience function for one-shot verification
- Uses the Standard Webhooks specification (which Polar uses for webhook signing)
- Handles base64 encoding of secrets internally, providing a cleaner API

## Usage

```go
// Option 1: Reusable verifier (recommended for handlers)
verifier, err := polargo.NewWebhookVerifier(webhookSecret)
if err != nil {
    // handle error
}
if err := verifier.Verify(payload, r.Header); err != nil {
    // signature invalid
}

// Option 2: One-shot validation
if err := polargo.ValidateWebhookSignature(payload, r.Header, webhookSecret); err != nil {
    // signature invalid
}
```

## Motivation

Currently, SDK users need to:
1. Import the `standard-webhooks` library separately
2. Manually base64-encode their webhook secret
3. Understand the Standard Webhooks spec

This PR provides a native SDK solution that hides these implementation details. As Python and Typescript sdk have this

## Test plan

- [x] Unit tests for `NewWebhookVerifier`
- [x] Unit tests for `Verify` with valid/invalid signatures
- [x] Unit tests for missing headers
- [x] Unit tests for wrong secret
- [x] Unit tests for `ValidateWebhookSignature` convenience function
- [x] All tests passing